### PR TITLE
Le boss ne réagit pas pendant le combat (bug d’IA)

### DIFF
--- a/boss/boss.tscn
+++ b/boss/boss.tscn
@@ -1,0 +1,1 @@
+bliblibli


### PR DESCRIPTION
Problème - Le boss ne réagit pas lorsque le joueur l’attaque. Il reste figé dans son animation de début de combat.

Solution : 
Le boss doit avoir un comportement d'attaque lorsque le joueur l’approche et subit des dégâts. La logique de l'IA doit être réactivée pour gérer ses attaques et ses déplacements.

Impact : 
Ce bug rend le combat avec le boss extrêmement facile, cassant l'expérience du joueur.

Etapes pour reproduire :
Lancer le combat avec le boss.
Attaquer le boss.
Observer qu'il ne répond pas à l’attaque et ne bouge pas.